### PR TITLE
Added closing bracket to gameTime

### DIFF
--- a/wys.asl
+++ b/wys.asl
@@ -86,6 +86,7 @@ gameTime {
     } else {
         return TimeSpan.FromSeconds(current.fulltime);
     }
+}
 
 start {
     // when in chapter mode:


### PR DESCRIPTION
Added the closing bracket to `gameTime` that was removed in commit 617bbe0bd2f98c533f1a22f6e4a76b2f3975c8d3.